### PR TITLE
Pretty Print JSON responses

### DIFF
--- a/netfox/NFXBodyDetailsController.swift
+++ b/netfox/NFXBodyDetailsController.swift
@@ -31,47 +31,9 @@ class NFXBodyDetailsController : UIViewController
         self.bodyView.textColor = UIColor.init(netHex: 0x707070)
         self.bodyView.editable = false
         
-        
-        // Added by Vicente Crespo Penadés
-        // vicente.crespo.penades@gmail.com - 23 Nov 2015
-        let responseBody = prettyStringIfPossibleWithResponse( tempObject.getResponseBody() as String)
-        
-        
-        self.bodyView.text = responseBody
+        self.bodyView.text = tempObject.getResponseBody() as String
         
         self.view.addSubview(self.bodyView)
         
     }
-    
-    
-    //
-    // MARK: Utils
-    //
-    
-    private func prettyStringIfPossibleWithResponse(response: String?) -> String? {
-        
-        guard let responseBody = response
-            else { return nil }
-        
-        do {
-            if let responseBodyData = responseBody.dataUsingEncoding(NSUTF8StringEncoding) {
-                
-                let responseObj = try NSJSONSerialization.JSONObjectWithData(responseBodyData,
-                    options: .AllowFragments)
-                
-                let dataResponse = try NSJSONSerialization.dataWithJSONObject(responseObj,
-                    options: .PrettyPrinted)
-                
-                let responseBodyPretty = String(data: dataResponse,
-                    encoding: NSUTF8StringEncoding)
-                
-                return responseBodyPretty
-            }
-        } catch {
-            return response
-        }
-        
-        return response
-    }
-    
 }


### PR DESCRIPTION
# Overview

I've moved the pretty printing of JSON into the model so it's not only valid on responses > 1024 bytes of data.

We now check the content type of the response before attempting to pretty print the data by converting to a simple enum. This could be extended in the future to include other content types (html / xml / images / e.t.c)

In theory this should work for both requests and responses but for some reason I'm not able to see my JSON request bodies (I'm currently trying to figure out why as it might be an Alamofire issue?) so if someone else could test that would be fantastic
