### PR TITLE
Workaround for issue #16

### DIFF
--- a/netfox/NFXHelper.swift
+++ b/netfox/NFXHelper.swift
@@ -87,11 +87,7 @@ extension NSURLRequest
     
     func getNFXBody() -> NSData
     {
-        if (HTTPBody != nil) {
-            return HTTPBody!
-        } else {
-            return NSData()
-        }
+        return HTTPBody ?? NSURLProtocol.propertyForKey("NFXBodyData", inRequest: self) as? NSData ?? NSData()
     }
 }
 


### PR DESCRIPTION
NFXBody will now check the NSURLProtocol for if a value is set for the body data.

This is to work around a problem where by the time NSURLProtocol.startLoading is called, the HTTPBody of the request and canonical request will both be nil

If you don't set the NFXBodyData property then it will be ignored and defaulted to the original behaviour of returning NSData()

If you want to log request data you should do something like the following:

```
if let bodyData = mutableURLRequest.HTTPBody {
  NSURLProtocol.setProperty(bodyData, forKey: "NFXBodyData", inRequest: mutableURLRequest)
}
```

Wherever you construct your NSMutableURLRequest's (for instance when using Alamofire - in URLRequest of URLRequestConvertible)

See: http://openradar.appspot.com/15993891