### PR TITLE
Duplicate versions netfox may be displayed (if you're super quick)

### DIFF
--- a/netfox/NFX.swift
+++ b/netfox/NFX.swift
@@ -112,11 +112,8 @@ public class NFX: NSObject
         navigationController!.navigationBar.barTintColor = UIColor.init(netHex: 0xccc5b9)
         navigationController!.navigationBar.titleTextAttributes = [NSForegroundColorAttributeName : UIColor.init(netHex: 0xec5e28)]
         
-        presentingViewController?.presentViewController(navigationController!, animated: true, completion: { () -> Void in
-            self.presented = true
-        })
-
-
+        self.presented = true
+        presentingViewController?.presentViewController(navigationController!, animated: true, completion: nil)
     }
     
     private var presentingViewController: UIViewController? {


### PR DESCRIPTION
A bug exists where it's possible to end up with multiple copies of the debug view controller presented.

It's easiest to reproduce in the simulator if you press ctrl+cmd+z twice in quick succession

It occurs because we don't mark the view controller as being presented until the animation has completed so if you trigger another presentation whilst it's animating it will attempt to present another version

I've fixed the issue by simply moving the boolean check before the completion callback - so we block any new presentations whilst we have allocated a new navigation controller for presentation

hideNFX is still correct by setting this boolean in the animation completion block since we should still block new presentations until it' finished being dismissed