### PR TITLE
Default headers not sent when using Alamofire with integration from workarounds

### DIFF
--- a/Workarounds.md
+++ b/Workarounds.md
@@ -10,6 +10,7 @@ class NFXManager: Alamofire.Manager
     static let sharedManager: NFXManager = {
         let configuration = NSURLSessionConfiguration.defaultSessionConfiguration()
         configuration.protocolClasses?.insert(NFXProtocol.self, atIndex: 0)
+        configuration.HTTPAdditionalHeaders = Manager.defaultHTTPHeaders
         let manager = NFXManager(configuration: configuration)
         return manager
     }()


### PR DESCRIPTION
When using Alamofire with a custom Manager the default headers were not being sent with every request

Updated the documentation to include the fact that you should also include the default HTTP headers when using Alamofire