### PR TITLE
Fix iPad crash when tapping on clear button

### DIFF
--- a/netfox/NFXSettingsController.swift
+++ b/netfox/NFXSettingsController.swift
@@ -189,7 +189,7 @@ class NFXSettingsController: NFXGenericController, UITableViewDelegate, UITableV
             break
             
         case 2:
-            clearDataButtonPressed()
+            clearDataButtonPressedOnTableIndex(indexPath)
             break
             
         default: break
@@ -257,10 +257,12 @@ class NFXSettingsController: NFXGenericController, UITableViewDelegate, UITableV
         }
     }
     
-    func clearDataButtonPressed()
+    func clearDataButtonPressedOnTableIndex(index: NSIndexPath)
     {
         let actionSheetController: UIAlertController = UIAlertController(title: "Clear data?", message: "", preferredStyle: .ActionSheet)
-        
+        actionSheetController.popoverPresentationController?.sourceView = tableView
+        actionSheetController.popoverPresentationController?.sourceRect = tableView.rectForRowAtIndexPath(index)
+
         let cancelAction: UIAlertAction = UIAlertAction(title: "Cancel", style: .Cancel) { action -> Void in
         }
         actionSheetController.addAction(cancelAction)


### PR DESCRIPTION
UIAlertController needs a sourceView and a sourceRect when using UIAlertControllerStyleActionSheet style on the iPad.

Related Crash info:
*** Terminating app due to uncaught exception 'NSGenericException', reason: 'Your application has presented a UIAlertController (<UIAlertController: 0x12ed9f130>) of style UIAlertControllerStyleActionSheet. The modalPresentationStyle of a UIAlertController with this style is UIModalPresentationPopover. You must provide location information for this popover through the alert controller's popoverPresentationController. You must provide either a sourceView and sourceRect or a barButtonItem.  If this information is not known when you present the alert controller, you may provide it in the UIPopoverPresentationControllerDelegate method -prepareForPopoverPresentation.'