### PR TITLE
Fixes crash trying to pretty print invalid JSON

### DIFF
--- a/netfox/NFXHTTPModel.swift
+++ b/netfox/NFXHTTPModel.swift
@@ -211,7 +211,7 @@ class NFXHTTPModel: NSObject
         switch type {
         case .JSON:
             do {
-                let rawJsonData = try NSJSONSerialization.JSONObjectWithData(rawData, options: [.AllowFragments])
+                let rawJsonData = try NSJSONSerialization.JSONObjectWithData(rawData, options: [])
                 let prettyPrintedString = try NSJSONSerialization.dataWithJSONObject(rawJsonData, options: [.PrettyPrinted])
                 return NSString(data: prettyPrintedString, encoding: NSUTF8StringEncoding) as? String
             } catch {


### PR DESCRIPTION
Parsing JSON with AllowFragments returns nil on non-json data without throwing an error. That causes dataWithJSONObject to crash with:

NSInvalidArgumentException, reason: *** +[NSJSONSerialization dataWithJSONObject:options:error:]: Invalid top-level type in JSON write