### PR TITLE
ADD: Support for NSURLSessionTasks

### DIFF
--- a/netfox/NFXProtocol.swift
+++ b/netfox/NFXProtocol.swift
@@ -15,6 +15,33 @@ public class NFXProtocol: NSURLProtocol
     
     override public class func canInitWithRequest(request: NSURLRequest) -> Bool
     {
+        if !canServeRequest(request) {
+            return false
+        }
+        
+        if NSURLProtocol.propertyForKey("NFXInternal", inRequest: request) != nil {
+            return false
+        }
+        
+        return true
+    }
+    
+    override public class func canInitWithTask(task: NSURLSessionTask) -> Bool {
+    
+        guard let request = task.currentRequest else { return false }
+        
+        if !canServeRequest(request) {
+            return false
+        }
+        
+        if NSURLProtocol.propertyForKey("NFXInternal", inRequest: task.currentRequest!) != nil {
+            return false
+        }
+        
+        return true
+    }
+    
+    private class func canServeRequest(request: NSURLRequest) -> Bool {
         if !NFX.sharedInstance().isEnabled() {
             return false
         }
@@ -30,10 +57,6 @@ public class NFXProtocol: NSURLProtocol
                 }
             }
         } else {
-            return false
-        }
-
-        if NSURLProtocol.propertyForKey("NFXInternal", inRequest: request) != nil {
             return false
         }
         


### PR DESCRIPTION
This fixes the issue where requests don't get logged if they are using NSURLSessionTasks. Please see issue https://github.com/kasketis/netfox/issues/32.

There are a couple of caveats. If you are using NSURLSessionTasks you must add the NSXProtocol to the protocolClasses on the NSUserSessionConfiguration.

For example:
**Obj-C**
```
NSURLSessionConfiguration* config = NSURLSessionConfiguration.defaultSessionConfiguration;
config.protocolClasses = @[[NFXProtocol class]];
```
**Swift**
```
let configuration = NSURLSessionConfiguration.defaultSessionConfiguration()
configuration.protocolClasses?.insert(NFXProtocol.self, atIndex: 0)
```

If someone has any ideas how we can accomplish loving these requests without setting the protocolClasses, please leave a comment.