### PR TITLE
FIX: Text alignment

### DIFF
--- a/netfox/NFXDetailsController.swift
+++ b/netfox/NFXDetailsController.swift
@@ -89,6 +89,7 @@ class NFXDetailsController: NFXGenericController, MFMailComposeViewControllerDel
         textLabel.numberOfLines = 0
         textLabel.attributedText = content
         textLabel.sizeToFit()
+		textLabel.textAlignment = .Left
         scrollView.addSubview(textLabel)
         
         var moreButton: UIButton

--- a/netfox/NFXRawBodyDetailsController.swift
+++ b/netfox/NFXRawBodyDetailsController.swift
@@ -22,6 +22,7 @@ class NFXRawBodyDetailsController: NFXGenericBodyDetailsController
         self.bodyView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
         self.bodyView.backgroundColor = UIColor.clearColor()
         self.bodyView.textColor = UIColor.NFXGray44Color()
+		self.bodyView.textAlignment = .Left
         self.bodyView.editable = false
         self.bodyView.font = UIFont.NFXFont(13)
         


### PR DESCRIPTION
With devices on RTL some texts get wrong alignment. Since "details"  always will be english, `text Alignment` maybe hardcoded with `.Left` 