### PR TITLE
Making it possible to manually save requests and responses

### DIFF
--- a/netfox.podspec
+++ b/netfox.podspec
@@ -13,7 +13,9 @@ DESC
   s.author           = "Christos Kasketis"
   s.source           = { :git => "https://github.com/kasketis/netfox.git", :tag => '1.7.2' }
 
-  s.platform     = :ios, '8.0'
+  s.ios.deployment_target = '8.0'
+  s.tvos.deployment_target = '9.0'
+  s.watchos.deployment_target = '2.0'
   s.requires_arc = true
 
   s.source_files = "netfox"

--- a/netfox/NFX.swift
+++ b/netfox/NFX.swift
@@ -50,14 +50,16 @@ public class NFX: NSObject
     private var started: Bool = false
     private var presented: Bool = false
     private var enabled: Bool = false
+    private var manualRecording:Bool = false
     private var selectedGesture: ENFXGesture = .shake
     private var ignoredURLs = [String]()
     private var filters = [Bool]()
     private var lastVisitDate: NSDate = NSDate()
-
-    @objc public func start()
+    
+    @objc public func start(manualRecording manualRecording:Bool = false)
     {
         self.started = true
+        self.manualRecording = manualRecording
         register()
         enable()
         clearOldData()
@@ -94,11 +96,13 @@ public class NFX: NSObject
     
     private func register()
     {
+        guard manualRecording == false else { return }
         NSURLProtocol.registerClass(NFXProtocol)
     }
     
     private func unregister()
     {
+        guard manualRecording == false else { return }
         NSURLProtocol.unregisterClass(NFXProtocol)
     }
     

--- a/netfox/NFX.swift
+++ b/netfox/NFX.swift
@@ -174,8 +174,8 @@ public class NFX: NSObject
     
     private var presentingViewController: UIViewController?
     {
-        let rootViewController = UIApplication.sharedApplication().keyWindow?.rootViewController
-        return rootViewController?.presentedViewController ?? rootViewController
+        let rootViewController = UIApplication.topViewController()
+        return rootViewController
     }
     
     private func hideNFX()
@@ -229,5 +229,30 @@ public class NFX: NSObject
             self.filters = [Bool](count: HTTPModelShortType.allValues.count, repeatedValue: true)
         }
         return self.filters
+    }
+}
+
+private extension UIApplication {
+    class func topViewController(base: UIViewController? = UIApplication.sharedApplication().keyWindow?.rootViewController) -> UIViewController? {
+        
+        if let nav = base as? UINavigationController {
+            return topViewController(nav.visibleViewController)
+        }
+        
+        if let tab = base as? UITabBarController {
+            let moreNavigationController = tab.moreNavigationController
+            
+            if let top = moreNavigationController.topViewController where top.view.window != nil {
+                return topViewController(top)
+            } else if let selected = tab.selectedViewController {
+                return topViewController(selected)
+            }
+        }
+        
+        if let presented = base?.presentedViewController {
+            return topViewController(presented)
+        }
+        
+        return base
     }
 }

--- a/netfox/NFXHTTPModel.swift
+++ b/netfox/NFXHTTPModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class NFXHTTPModel: NSObject
+public class NFXHTTPModel: NSObject
 {
     var requestURL: String?
     var requestMethod: String?
@@ -34,7 +34,7 @@ class NFXHTTPModel: NSObject
     
     var noResponse: Bool = true
     
-    func saveRequest(request: NSURLRequest)
+    public func saveRequest(request: NSURLRequest)
     {
         self.requestDate = NSDate()
         self.requestTime = getTimeFromDate(self.requestDate!)

--- a/netfox/NFXHTTPModel.swift
+++ b/netfox/NFXHTTPModel.swift
@@ -47,7 +47,7 @@ public class NFXHTTPModel: NSObject
         saveRequestBodyData(request.getNFXBody())
     }
     
-    func saveResponse(response: NSURLResponse, data: NSData)
+    public func saveResponse(response: NSURLResponse, data: NSData)
     {
         self.noResponse = false
         

--- a/netfox/NFXHTTPModelManager.swift
+++ b/netfox/NFXHTTPModelManager.swift
@@ -9,12 +9,12 @@ import Foundation
 
 private let _sharedInstance = NFXHTTPModelManager()
 
-final class NFXHTTPModelManager: NSObject
+public final class NFXHTTPModelManager: NSObject
 {
-    static let sharedInstance = NFXHTTPModelManager()
+    public static let sharedInstance = NFXHTTPModelManager()
     private var models = [NFXHTTPModel]()
     
-    func add(obj: NFXHTTPModel)
+    public func add(obj: NFXHTTPModel)
     {
         self.models.insert(obj, atIndex: 0)
     }


### PR DESCRIPTION
As marked in issue https://github.com/kasketis/netfox/issues/53, caching will be disabled by using the `NFXProtocol`. 

To fix this I wrote a plugin for our Moya library, which uses the methods which are changed to public:

```
import Moya
import Result
import netfox

public typealias TIFEndpointClosure = TIFAPI -> NSURLRequest

public final class TIFNetfoxPlugin {

    var modelsDict = [Int: NFXHTTPModel]()
    let endpointClosure:TIFEndpointClosure

    public init(endpointClosure:TIFEndpointClosure){
        self.endpointClosure = endpointClosure
    }
}

extension TIFNetfoxPlugin : PluginType {
    /// Called by the provider as soon as the request is about to start
    public func willSendRequest(request: RequestType, target: TargetType) {
        guard let tifTarget = target as? TIFAPI else { return }

        let urlRequest = endpointClosure(tifTarget)
        let model = NFXHTTPModel()
        model.saveRequest(urlRequest)
        modelsDict[urlRequest.hash] = model
    }

    /// Called by the provider as soon as a response arrives
    public func didReceiveResponse(result: Result<Moya.Response, Moya.Error>, target: TargetType) {
        guard let tifTarget = target as? TIFAPI else { return }
        let urlRequest = endpointClosure(tifTarget)

        guard let model = modelsDict[urlRequest.hash] else { return }

        if case .Success(let response) = result, let urlResponse = response.response {
            model.saveResponse(urlResponse, data: response.data)
        }

        NFXHTTPModelManager.sharedInstance.add(model)
    }
}

public extension Hashable where Self:TargetType {
    var hashValue: Int {
        return baseURL.hash
    }
}
```

This makes it possible for users to write their own class for saving requests and responses, without having to disable caching.
