### PR TITLE
Fix macOS podspec

### DIFF
--- a/netfox.podspec
+++ b/netfox.podspec
@@ -11,15 +11,13 @@ DESC
   s.screenshots      = "https://raw.githubusercontent.com/kasketis/netfox/master/assets/overview1_5_3.gif"
   s.license          = 'MIT'
   s.author           = "Christos Kasketis"
-  s.source           = { :git => "https://github.com/kasketis/netfox.git", :tag => '1.8' }
+  s.source           = { :git => "https://github.com/kasketis/netfox.git", :tag => "#{s.version}" }
 
   s.ios.deployment_target   = '8.0'
   s.osx.deployment_target   = '10.10'
+
   s.requires_arc = true
-
-  s.ios.source_files = "netfox/Core/*.swift", "netfox/iOS/*.swift"
-  s.osx.source_files = "netfox/Core/*.swift", "netfox/OSX/*.{swift,xib}"
-
-  s.ios.source_files      = 'Sources/ios/*.swift' 
-  s.osx.source_files      = 'Sources/osx/*.swift' 
+  s.source_files = "netfox/Core/*.swift"
+  s.ios.source_files = "netfox/iOS/*.swift"
+  s.osx.source_files = "netfox/OSX/*.{swift,xib}"  
 end

--- a/netfox.podspec
+++ b/netfox.podspec
@@ -13,10 +13,13 @@ DESC
   s.author           = "Christos Kasketis"
   s.source           = { :git => "https://github.com/kasketis/netfox.git", :tag => '1.8' }
 
-  s.platform     = :ios, '8.0'
-  s.platform     = :osx, '10.0'
+  s.ios.deployment_target   = '8.0'
+  s.osx.deployment_target   = '10.10'
   s.requires_arc = true
 
-  s.ios.source_files = "netfox/Core/*.swift" , "netfox/iOS/*.swift"
-  s.osx.source_files = "netfox/Core/*.swift" , "netfox/OSX/*.swift"
+  s.ios.source_files = "netfox/Core/*.swift", "netfox/iOS/*.swift"
+  s.osx.source_files = "netfox/Core/*.swift", "netfox/OSX/*.{swift,xib}"
+
+  s.ios.source_files      = 'Sources/ios/*.swift' 
+  s.osx.source_files      = 'Sources/osx/*.swift' 
 end


### PR DESCRIPTION
There was some issue in the podspec which was making the pod not usable for macOS. That PR should fix them. Until now we were still using our own clone of netfox, but we'd like to move on the main repository once that PR merged.

I didn't forget about the gif you asked, but in order to do it, the best way should be to add a demo project to netfox directly. Since I can't share our API logs (private stuff), that could be a nice way to handle the issue.

Also, just a suggestion, do you mind to add some contributors to the project? There are some PRs / fixed that look pretty interesting. Mainly the ones which migrate netfox to Swift 2.{2,3}. It would be for the best if netfox can support swift 3 before it's released!