### PR TITLE
Support JSON API headers  (application/vnd.api+json)

### DIFF
--- a/netfox/Core/NFXHTTPModel.swift
+++ b/netfox/Core/NFXHTTPModel.swift
@@ -210,7 +210,8 @@ class NFXHTTPModel: NSObject
     
     func getShortTypeFrom(_ contentType: String) -> HTTPModelShortType
     {
-        if contentType == "application/json" {
+        if NSPredicate(format: "SELF MATCHES %@",
+                                "^application/(vnd\\.(.*)\\+)?json$").evaluate(with: contentType) {
             return .JSON
         }
         


### PR DESCRIPTION
This PR detects [JSON API](http://jsonapi.org/format/) headers (e.g. application/vnd.api+json) as JSON APIs in order for them to be parsed & presented correctly.