### PR TITLE
Added left close button in NFXListController_iOS + NFX.toggle()

### DIFF
--- a/netfox/Core/NFX.swift
+++ b/netfox/Core/NFX.swift
@@ -117,13 +117,8 @@ open class NFX: NSObject
     
     func motionDetected()
     {
-        if self.started {
-            if self.presented {
-                hideNFX()
-            } else {
-                showNFX()
-            }
-        }
+        guard self.started else { return }
+        toggleNFX()
     }
     
     @objc open func setGesture(_ gesture: ENFXGesture)
@@ -140,20 +135,20 @@ open class NFX: NSObject
     
     @objc open func show()
     {
-        if (self.started) && (self.selectedGesture == .custom) {
-            showNFX()
-        } else {
-            print("netfox \(nfxVersion) - [ERROR]: Please call start() and setGesture(.custom) first")
-        }
+        guard self.started else { return }
+        showNFX()
     }
     
     @objc open func hide()
     {
-        if (self.started) && (self.selectedGesture == .custom) {
-            hideNFX()
-        } else {
-            print("netfox \(nfxVersion) - [ERROR]: Please call start() and setGesture(.custom) first")
-        }
+        guard self.started else { return }
+        hideNFX()
+    }
+
+    @objc open func toggle()
+    {
+        guard self.started else { return }
+        toggleNFX()
     }
     
     @objc open func ignoreURL(_ url: String)
@@ -188,6 +183,11 @@ open class NFX: NSObject
             self.presented = false
             self.lastVisitDate = Date()
         }
+    }
+
+    fileprivate func toggleNFX()
+    {
+        self.presented ? hideNFX() : showNFX()
     }
     
     internal func clearOldData()

--- a/netfox/Core/NFXAssets.swift
+++ b/netfox/Core/NFXAssets.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum NFXAssetName {
     case settings
+    case close
     case info
     case statistics
 }
@@ -17,31 +18,26 @@ class NFXAssets
 {
     class func getImage(_ image: NFXAssetName) -> Data
     {
-        var base64Image: String
+        var base64Image: String = {
+            switch image {
+            case .settings: return getSettingsImageBase64()
+            case .close: return getCloseImageBase64()
+            case .info: return getInfoImageBase64()
+            case .statistics: return getStatisticsImageBase64()
+            }
+        }()
 
-        switch image {
-        case .settings:
-            base64Image = getSettingsImageBase64()
-            break
-        case .info:
-            base64Image = getInfoImageBase64()
-            break
-        case .statistics:
-            base64Image = getStatisticsImageBase64()
-            break
-        }
-        
-        if let imageData = Data(base64Encoded: base64Image, options: NSData.Base64DecodingOptions.ignoreUnknownCharacters) {
-            return imageData
-        } else {
-            return Data()
-        }
+        return Data(base64Encoded: base64Image, options: NSData.Base64DecodingOptions.ignoreUnknownCharacters) ?? Data()
     }
-    
-    
+
     class func getSettingsImageBase64() -> String
     {
         return "iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAMAAAApWqozAAAAjVBMVEUAAADsXijtXSfsXSftXijsXibsXSftXibtXSftXijtXSftXSXtXijtXijtXibtXSftXSfsXijsXSfuXSbsXijtXiftXSfuXSbtXijsXSjsXSjsXSjsXSftXSbsXSftXijtXibtXSftXSbuXSXtXSfsXifsXSftXibtXibsXSjtXSjtXSbtXyXtXibsXigoILJHAAAALnRSTlMA+wPDvSDAgdqtlhUH1GpRGOnIk/j0XS7vz6mkdR0PtJw7MguQZFl8VuzMRSaGMJ3GQwAAAi5JREFUOMulVdm2ojAQTEJYZRcQBBQVl+tS//95MwGDAQev50xeslWS7upONXlvfp4kNMkz8k1bo9A0D85XYC8/ELKh2jfYBb12R9LDPGa5ZP1gh1J0Nvb93F2WbIoFilU3CnAWnYmgm648wJ5iuQNaiU3eoy7g4rBPseRYq1gHhksuCZyTBli6WNItgAct6IW4HPbLklZgu0sBO9j0i5tgC8D4a7lAlwP4Id9Z2nf1wdXWkdQ/Xqsc/ic2fXCV2xSreewK6UKdZyjYLLjAacqdmguuO6KqnZy+YSuHuqlFkXbW5VzDbgK+Qm5WACwLQPVc2MMYY/UhpA1Sv2as9lM0w9XhAGTh7mjg1k9MGIsnQwZM6f022y2YeLW0IB7uE7LGz2Lg8wd1NwgjANQrKwL8XMvqEsqLj2RoR3m1fjqX1xwgSbFRbI+pQn9IY2VrUyRk9H3cyFLdtiKVb40SanwLNihJvJCpZoQzZrDQS4jw0z7/5qBpexQgxzZOX9Tps9SlWpt1fu6z34Jy2iuc3Ydwl8jfw70goxZ/SiT+IUXP4xSN31K0QTuf/M70S37QwRjHUTrTVJ8H3ylVdlmBgHxoJ+U7s8HgZkZkHDRMgh1wEcDdtZOvgypfsWDiwLFmqjAy4gNmEANePQjj7QH4hElhHGTDWCPKRAiMkeRmOdZSchU0eP30plLFXDekmKtok8gy0YzKBDHLeWULEcsC9FVpc2Vp+/+iOS3H9N/l+A8JizxgzuMcJQAAAABJRU5ErkJggg=="
+    }
+
+    class func getCloseImageBase64() -> String
+    {
+        return "iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAYAAAAehFoBAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAfhJREFUeNrs2FFOwzAMANA2qrgAp+BUfFGkZZPaIcEV4Gfjo+WD7YdTcQoOgIYojuQgq2ppHLvdhhop6jZNy6vnuEnSpmmSc2rpDJ7B/xX8cX1lL9/e66EfgO+JADAGa2zTg1jCpYJrNXUEYcwtjr0OBsPdOai7QzslGrEF9B0YNsFgRC8Jup4Ym/d9zwzkl0O/QF+MGWn47U0INrhKINa6iONNqE06aA5bhmAHI9yTHpqRZmGDwSPl9JaLZYE7croWYl3O7jnY6CcdYheIt5HYV+i3XQ8OtQiTSFsfaVfkY7ExY5vY/xTRNUa4YmB3sVgRuD0R8RqCzSVjZgqz3ddlh27Ie3WsFriN/oR+h++fNLGaYI92WL/K+oJ+j/m90hpEE5yQyHq0KlY86Xraoef1SUb4EfoDRvaAj14a8ZMC+4VMOw3cZxcd1eOo4N9VVwu7RqyrHmnEY3wUMMXmAyUvkaJFYLqtGaizauhsAixFp7hg+o4td5kQy111WcT6iLPRRoKFxU/MqmuFlWQ5sGCSgwl2H4ml6Kidi2Fg6Vb8RqG6+CUp6wjBMLAlpoHKqotMRNZu3ASmQSnIWdUjBMM4PlLHxhwhmMBqkCcjN4L+cyL2HbdaYemSoH31KILBeJhcTolt7cYLuD6rHaQcs83gGXzu4B8BBgBA+BOxy8YHYQAAAABJRU5ErkJggg=="
     }
     
     class func getInfoImageBase64() -> String

--- a/netfox/Core/NFXHelper.swift
+++ b/netfox/Core/NFXHelper.swift
@@ -197,6 +197,15 @@ extension NFXImage
         return NSImage(data: NFXAssets.getImage(NFXAssetName.settings))!
     #endif
     }
+
+    class func NFXClose() -> NFXImage
+    {
+    #if os (iOS)
+        return UIImage(data: NFXAssets.getImage(NFXAssetName.close), scale: 1.7)!
+    #elseif os(OSX)
+        return NSImage(data: NFXAssets.getImage(NFXAssetName.close))!
+    #endif
+    }
     
     class func NFXInfo() -> NFXImage
     {

--- a/netfox/iOS/NFXListController_iOS.swift
+++ b/netfox/iOS/NFXListController_iOS.swift
@@ -37,7 +37,9 @@ class NFXListController_iOS: NFXListController, UITableViewDelegate, UITableView
         self.view.addSubview(self.tableView)
         
         self.tableView.register(NFXListCell.self, forCellReuseIdentifier: NSStringFromClass(NFXListCell.self))
-        
+
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage.NFXClose(), style: .plain, target: self, action: #selector(NFXListController_iOS.closeButtonPressed))
+
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage.NFXSettings(), style: .plain, target: self, action: #selector(NFXListController_iOS.settingsButtonPressed))
 
         let searchView = UIView()
@@ -85,6 +87,11 @@ class NFXListController_iOS: NFXListController, UITableViewDelegate, UITableView
         var settingsController: NFXSettingsController_iOS
         settingsController = NFXSettingsController_iOS()
         self.navigationController?.pushViewController(settingsController, animated: true)
+    }
+
+    func closeButtonPressed()
+    {
+        NFX.sharedInstance().hide()
     }
     
     // MARK: UISearchResultsUpdating


### PR DESCRIPTION
This PR adds a close button to the top-left of the Search bar on the list controller. 

<img width="380" alt="8128cdb3-1155-4ece-b3b3-cd9d21986f26" src="https://user-images.githubusercontent.com/605076/30324631-6a385a08-97ca-11e7-82f9-8b27eec2c384.png">

This is needed specifically if using a custom gesture. For example, if you use a 3-finger-swipe on your UIWindow to show Netfox, you will have no way to hide it since that Gesture recognizer only applies to the App’s window. 

I’ve also 
- Added NFX.toggle() that does a show/hide based on presentation status
- Removed the dependency on the “custom” gesture for show/hide - I don’t think only custom gestures would be interested in showing and hiding the controller. 