### PR TITLE
`NFX.sharedInstance()` accessibility in ObjC when mixed with Swift 4

### DIFF
--- a/netfox/Core/NFX.swift
+++ b/netfox/Core/NFX.swift
@@ -38,7 +38,7 @@ open class NFX: NSObject
     }
     
     // the sharedInstance class method can be reached from ObjC
-    open class func sharedInstance() -> NFX
+    @objc open class func sharedInstance() -> NFX
     {
         return NFX.swiftSharedInstance
     }


### PR DESCRIPTION
`NFX.sharedInstance()` was inaccessible in ObjC when the project was mixed with Swift 4.  This small PR fixes that.