### PR TITLE
Fix warning on NFXGenericController.swift

### DIFF
--- a/netfox/Core/NFXGenericController.swift
+++ b/netfox/Core/NFXGenericController.swift
@@ -38,7 +38,7 @@ class NFXGenericController: NFXViewController
         var tempMutableString = NSMutableAttributedString()
         tempMutableString = NSMutableAttributedString(string: string)
         
-        let l = string.characters.count
+        let l = string.count
         
         let regexBodyHeaders = try! NSRegularExpression(pattern: "(\\-- Body \\--)|(\\-- Headers \\--)", options: NSRegularExpression.Options.caseInsensitive)
         let matchesBodyHeaders = regexBodyHeaders.matches(in: string, options: NSRegularExpression.MatchingOptions.withoutAnchoringBounds, range: NSMakeRange(0, l)) as Array<NSTextCheckingResult>


### PR DESCRIPTION
Fix warning : 'characters' is deprecated: Please use String or Substring directly