### PR TITLE
Fix for Issue #36

### DIFF
--- a/netfox/Core/NFXConstants.swift
+++ b/netfox/Core/NFXConstants.swift
@@ -11,7 +11,7 @@ import UIKit
 typealias NFXColor = UIColor
 typealias NFXFont = UIFont
 typealias NFXImage = UIImage
-typealias NFXViewController = UIViewController
+public typealias NFXViewController = UIViewController
     
 #elseif os(OSX)
 import Cocoa
@@ -19,5 +19,5 @@ import Cocoa
 typealias NFXColor = NSColor
 typealias NFXFont = NSFont
 typealias NFXImage = NSImage
-typealias NFXViewController = NSViewController
+public typealias NFXViewController = NSViewController
 #endif

--- a/netfox/Core/NFXHelper.swift
+++ b/netfox/Core/NFXHelper.swift
@@ -445,8 +445,8 @@ extension String
 }
 
 public extension NSNotification.Name {
-    static let NFXDeactivateSearch = Notification.Name("NFXDeactivateSearch")
-    static let NFXReloadData = Notification.Name("NFXReloadData")
+    public static let NFXDeactivateSearch = Notification.Name("NFXDeactivateSearch")
+    public static let NFXReloadData = Notification.Name("NFXReloadData")
     public static let NFXAddedModel = Notification.Name("NFXAddedModel")
     public static let NFXClearedModels = Notification.Name("NFXClearedModels")
 }

--- a/netfox/Core/NFXListController.swift
+++ b/netfox/Core/NFXListController.swift
@@ -8,13 +8,26 @@
 import Foundation
 
 class NFXListController: NFXGenericController {
-
+    
     var tableData = [NFXHTTPModel]()
     var filteredTableData = [NFXHTTPModel]()
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()        
     }
+    
+    #if os(OSX)
+    override func viewDidDisappear() {
+        super.viewDidDisappear()
+        NFX.sharedInstance().lastVisitDate = Date()
+    }
+    #elseif os(iOS)
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        NFX.sharedInstance().lastVisitDate = Date()
+    }
+    #endif
+    
     
     
     func updateSearchResultsForSearchControllerWithString(_ searchString: String)
@@ -28,7 +41,7 @@ class NFXListController: NFXGenericController {
         let array = (NFXHTTPModelManager.sharedInstance.getModels() as NSArray).filtered(using: searchPredicate)
         self.filteredTableData = array as! [NFXHTTPModel]
     }
-
+    
     @objc func reloadTableViewData()
     {
     }

--- a/netfox/OSX/NFXListCell_OSX.swift
+++ b/netfox/OSX/NFXListCell_OSX.swift
@@ -110,7 +110,7 @@ class NFXListCell_OSX: NSTableCellView
     
     func isNewBasedOnDate(responseDate: NSDate)
     {
-        if responseDate.isGreaterThan(NFX.sharedInstance().getLastVisitDate()) {
+        if responseDate.isGreaterThan(NFX.sharedInstance().lastVisitDate) {
             self.isNew()
         } else {
             self.isOld()

--- a/netfox/iOS/NFXListCell_iOS.swift
+++ b/netfox/iOS/NFXListCell_iOS.swift
@@ -177,7 +177,7 @@ class NFXListCell: UITableViewCell
     
     func isNewBasedOnDate(_ responseDate: Date)
     {
-        if responseDate.isGreaterThanDate(NFX.sharedInstance().getLastVisitDate()) {
+        if responseDate.isGreaterThanDate(NFX.sharedInstance().lastVisitDate) {
             self.isNew()
         } else {
             self.isOld()


### PR DESCRIPTION
Here's a suggested fix for issue #36.

Here are some design considerations around the manual showing:

On showing:
`if NFX.started` - I check this value in the new method, `showManually()`
`NFX.presented = true` - At this point Netfox will no longer control whether the window has already been presented, that is the job of the new presenter.  If Netfox is asked to show using `show()`, it will (and should) do so.

On hiding:
`if !NFX.presented` - Same as above, Netfox is no longer in charge if they used `showManually()`
`NotificationCenter.default.post` - If the user wishes to deactivate the search window on disappearing, they are free to do so.  The notification has been publicly exposed.  I'd love to have more discussion as to why we (Netfox) even needs to do this.  At first glance, it seems like we're having a memory leak.  Once the window is shown and dismissed, whether the search controller is active shouldn't matter anymore, it should be deallocated.
`NFX.lastVisitDate` - I moved this logic into `NFXListController`'s `ViewWillDisappear` method.  It makes a little more sense to do so, since `NFXListController` is the only one that cares about it.  I left the actual property in NFX, simply because another class might be interested in this value as well (in the future)