### PR TITLE
Fixed request timeouts when sending multipart/form-data

### DIFF
--- a/netfox/Core/NFXHTTPModel.swift
+++ b/netfox/Core/NFXHTTPModel.swift
@@ -55,9 +55,16 @@ fileprivate func < <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
         self.requestTimeout = request.getNFXTimeout()
         self.requestHeaders = request.getNFXHeaders()
         self.requestType = requestHeaders?["Content-Type"] as! String?
+    }
+    
+    func saveRequestBody(_ request: URLRequest)
+    {
         saveRequestBodyData(request.getNFXBody())
+    }
+    
+    func logRequest(_ request: URLRequest)
+    {
         formattedRequestLogEntry().appendToFile(filePath: NFXPath.SessionLog)
-
     }
     
     func saveErrorResponse()

--- a/netfox/Core/NFXProtocol.swift
+++ b/netfox/Core/NFXProtocol.swift
@@ -69,6 +69,9 @@ open class NFXProtocol: URLProtocol
         
         session!.dataTask(with: req as URLRequest, completionHandler: {data, response, error in
             
+            self.model?.saveRequestBody(req as URLRequest)
+            self.model?.logRequest(req as URLRequest)
+            
             if let error = error {
                 self.model?.saveErrorResponse()
                 self.loaded()


### PR DESCRIPTION
I separated the saving of http request body from the saving of other request properties in NFXHTTPModel.saveRequest(request: URLRequest) to avoid concurrent reads from httpBodyStream. The request body is saved only after the response is received. If two threads read concurrently from the same InputStream, both of them will get incomplete data. 

The change might also fix this issue: 
[https://github.com/kasketis/netfox/issues/116](url)