### PR TITLE
Xcode 10 - Swift 4 & Swift 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@
 # * https://github.com/supermarin/xcpretty#usage
 
 os: osx
-osx_image: xcode9.2
+osx_image: xcode10
 language: swift
 script:
-- set -o pipefail && xcodebuild -project netfox.xcodeproj -scheme netfox_ios -sdk iphoneos11.2 ONLY_ACTIVE_ARCH=NO SWIFT_VERSION=4.0 | xcpretty
-- set -o pipefail && xcodebuild -project netfox.xcodeproj -scheme netfox_ios -sdk iphoneos11.2 ONLY_ACTIVE_ARCH=NO SWIFT_VERSION=3.2 | xcpretty
-- set -o pipefail && xcodebuild -project netfox.xcodeproj -scheme netfox_osx -sdk macosx10.13 ONLY_ACTIVE_ARCH=NO SWIFT_VERSION=4.0 | xcpretty
-- set -o pipefail && xcodebuild -project netfox.xcodeproj -scheme netfox_osx -sdk macosx10.13 ONLY_ACTIVE_ARCH=NO SWIFT_VERSION=3.2 | xcpretty
+- set -o pipefail && xcodebuild -project netfox.xcodeproj -scheme netfox_ios -sdk iphoneos12 ONLY_ACTIVE_ARCH=NO SWIFT_VERSION=4.0 | xcpretty
+- set -o pipefail && xcodebuild -project netfox.xcodeproj -scheme netfox_ios -sdk iphoneos12 ONLY_ACTIVE_ARCH=NO SWIFT_VERSION=4.2 | xcpretty
+- set -o pipefail && xcodebuild -project netfox.xcodeproj -scheme netfox_osx -sdk macosx10.14 ONLY_ACTIVE_ARCH=NO SWIFT_VERSION=4.0 | xcpretty
+- set -o pipefail && xcodebuild -project netfox.xcodeproj -scheme netfox_osx -sdk macosx10.14 ONLY_ACTIVE_ARCH=NO SWIFT_VERSION=4.2 | xcpretty
 - pod lib lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ os: osx
 osx_image: xcode10
 language: swift
 script:
-- set -o pipefail && xcodebuild -project netfox.xcodeproj -scheme netfox_ios -sdk iphoneos12 ONLY_ACTIVE_ARCH=NO SWIFT_VERSION=4.0 | xcpretty
-- set -o pipefail && xcodebuild -project netfox.xcodeproj -scheme netfox_ios -sdk iphoneos12 ONLY_ACTIVE_ARCH=NO SWIFT_VERSION=4.2 | xcpretty
+- set -o pipefail && xcodebuild -project netfox.xcodeproj -scheme netfox_ios -sdk iphonesimulator12.0 ONLY_ACTIVE_ARCH=NO SWIFT_VERSION=4.0 | xcpretty
+- set -o pipefail && xcodebuild -project netfox.xcodeproj -scheme netfox_ios -sdk iphonesimulator12.0 ONLY_ACTIVE_ARCH=NO SWIFT_VERSION=4.2 | xcpretty
 - set -o pipefail && xcodebuild -project netfox.xcodeproj -scheme netfox_osx -sdk macosx10.14 ONLY_ACTIVE_ARCH=NO SWIFT_VERSION=4.0 | xcpretty
 - set -o pipefail && xcodebuild -project netfox.xcodeproj -scheme netfox_osx -sdk macosx10.14 ONLY_ACTIVE_ARCH=NO SWIFT_VERSION=4.2 | xcpretty
-- pod lib lint
+- pod lib lint --quick

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ It grabs all requests - of course yours, requests from 3rd party libraries (such
 
 Very useful and handy for network related issues and bugs
 
-Supports Swift 3.2 and 4 - bridged also for Objective-C
+Supports Swift 4 and above - bridged also for Objective-C.
+
+For Swift 3.2 support, use version [1.12.1](https://github.com/kasketis/netfox/releases/tag/1.12.1).
 
 Feel free to contribute :)
 

--- a/netfox.podspec
+++ b/netfox.podspec
@@ -13,6 +13,7 @@ DESC
   s.author           = "Christos Kasketis"
   s.source           = { :git => "https://github.com/kasketis/netfox.git", :tag => "#{s.version}" }
 
+  s.swift_version = '4.0'
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.11'
   s.requires_arc = true

--- a/netfox.podspec
+++ b/netfox.podspec
@@ -13,7 +13,6 @@ DESC
   s.author           = "Christos Kasketis"
   s.source           = { :git => "https://github.com/kasketis/netfox.git", :tag => "#{s.version}" }
 
-  s.swift_version = '4.0'
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.11'
   s.requires_arc = true

--- a/netfox/Core/NFX.swift
+++ b/netfox/Core/NFX.swift
@@ -260,11 +260,7 @@ extension NFX {
         navigationController.navigationBar.isTranslucent = false
         navigationController.navigationBar.tintColor = UIColor.NFXOrangeColor()
         navigationController.navigationBar.barTintColor = UIColor.NFXStarkWhiteColor()
-        #if !swift(>=4.0)
-            navigationController.navigationBar.titleTextAttributes = [NSForegroundColorAttributeName: UIColor.NFXOrangeColor()]
-        #else
-            navigationController.navigationBar.titleTextAttributes = [NSAttributedStringKey.foregroundColor: UIColor.NFXOrangeColor()]
-        #endif
+        navigationController.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.NFXOrangeColor()]
         
         presentingViewController?.present(navigationController, animated: true, completion: nil)
     }
@@ -309,11 +305,13 @@ extension NFX {
     
     public func showNFXFollowingPlatform()  {
         if self.windowController == nil {
-            #if !swift(>=4.0)
-                self.windowController = NFXWindowController(windowNibName: "NetfoxWindow")
+            #if swift(>=4.2)
+            let nibName = "NetfoxWindow"
             #else
-                self.windowController = NFXWindowController(windowNibName: NSNib.Name(rawValue: "NetfoxWindow"))
+            let nibName = NSNib.Name(rawValue: "NetfoxWindow")
             #endif
+
+            self.windowController = NFXWindowController(windowNibName: nibName)
         }
         self.windowController?.showWindow(nil)
     }

--- a/netfox/Core/NFXGenericController.swift
+++ b/netfox/Core/NFXGenericController.swift
@@ -44,26 +44,16 @@ class NFXGenericController: NFXViewController
         let matchesBodyHeaders = regexBodyHeaders.matches(in: string, options: NSRegularExpression.MatchingOptions.withoutAnchoringBounds, range: NSMakeRange(0, l)) as Array<NSTextCheckingResult>
         
         for match in matchesBodyHeaders {
-            #if !swift(>=4.0)
-                tempMutableString.addAttribute(NSFontAttributeName, value: NFXFont.NFXFontBold(size: 14), range: match.range)
-                tempMutableString.addAttribute(NSForegroundColorAttributeName, value: NFXColor.NFXOrangeColor(), range: match.range)
-            #else
-                tempMutableString.addAttribute(NSAttributedStringKey.font, value: NFXFont.NFXFontBold(size: 14), range: match.range)
-                tempMutableString.addAttribute(NSAttributedStringKey.foregroundColor, value: NFXColor.NFXOrangeColor(), range: match.range)
-            #endif
+            tempMutableString.addAttribute(.font, value: NFXFont.NFXFontBold(size: 14), range: match.range)
+            tempMutableString.addAttribute(.foregroundColor, value: NFXColor.NFXOrangeColor(), range: match.range)
         }
         
         let regexKeys = try! NSRegularExpression(pattern: "\\[.+?\\]", options: NSRegularExpression.Options.caseInsensitive)
         let matchesKeys = regexKeys.matches(in: string, options: NSRegularExpression.MatchingOptions.withoutAnchoringBounds, range: NSMakeRange(0, l)) as Array<NSTextCheckingResult>
         
         for match in matchesKeys {
-            #if !swift(>=4.0)
-                tempMutableString.addAttribute(NSForegroundColorAttributeName, value: NFXColor.NFXBlackColor(), range: match.range)
-            #else
-                tempMutableString.addAttribute(NSAttributedStringKey.foregroundColor, value: NFXColor.NFXBlackColor(), range: match.range)
-            #endif
+            tempMutableString.addAttribute(.foregroundColor, value: NFXColor.NFXBlackColor(), range: match.range)
         }
-        
         
         return tempMutableString
     }

--- a/netfox/OSX/NFXSettingsController_OSX.swift
+++ b/netfox/OSX/NFXSettingsController_OSX.swift
@@ -25,12 +25,15 @@ class NFXSettingsController_OSX: NFXSettingsController, NSTableViewDataSource, N
         
         nfxVersionLabel.stringValue = nfxVersionString
         nfxURLButton.title = nfxURL
-        
-        #if !swift(>=4.0)
-            responseTypesTableView.register(NSNib(nibNamed: cellIdentifier, bundle: nil), forIdentifier: cellIdentifier)
+
+        #if swift(>=4.2)
+        let nibName = cellIdentifier
         #else
-            responseTypesTableView.register(NSNib(nibNamed: NSNib.Name(rawValue: cellIdentifier), bundle: nil), forIdentifier: NSUserInterfaceItemIdentifier(rawValue: cellIdentifier))
+        let nibName = NSNib.Name(rawValue: cellIdentifier)
         #endif
+
+        responseTypesTableView.register(NSNib(nibNamed: nibName, bundle: nil),
+                                        forIdentifier: NSUserInterfaceItemIdentifier(rawValue: cellIdentifier))
         
         reloadTableData()
     }
@@ -63,11 +66,7 @@ class NFXSettingsController_OSX: NFXSettingsController, NSTableViewDataSource, N
     }
     
     @IBAction func nfxURLButtonClicked(sender: NSButton) {
-        #if !swift(>=4.0)
-            NSWorkspace.shared().open(NSURL(string: nfxURL)! as URL)
-        #else
-            NSWorkspace.shared.open(NSURL(string: nfxURL)! as URL)
-        #endif
+        NSWorkspace.shared.open(URL(string: nfxURL)!)
     }
     
     @IBAction func toggleResponseTypeClicked(sender: NSButton) {

--- a/netfox/iOS/NFXDetailsController_iOS.swift
+++ b/netfox/iOS/NFXDetailsController_iOS.swift
@@ -76,11 +76,11 @@ class NFXDetailsController_iOS: NFXDetailsController, MFMailComposeViewControlle
 
         // Swipe gestures
         let lswgr = UISwipeGestureRecognizer(target: self, action: #selector(NFXDetailsController_iOS.handleSwipe(_:)))
-        lswgr.direction = UISwipeGestureRecognizerDirection.left
+        lswgr.direction = .left
         self.view.addGestureRecognizer(lswgr)
 
         let rswgr = UISwipeGestureRecognizer(target: self, action: #selector(NFXDetailsController_iOS.handleSwipe(_:)))
-        rswgr.direction = UISwipeGestureRecognizerDirection.right
+        rswgr.direction = .right
         self.view.addGestureRecognizer(rswgr)
 
         infoButtonPressed()
@@ -93,8 +93,8 @@ class NFXDetailsController_iOS: NFXDetailsController, MFMailComposeViewControlle
         tempButton.frame = CGRect(x: x, y: 0, width: self.view.frame.width / 3, height: 44)
         tempButton.autoresizingMask = [.flexibleLeftMargin, .flexibleRightMargin, .flexibleWidth]
         tempButton.backgroundColor = UIColor.NFXDarkStarkWhiteColor()
-        tempButton.setTitle(title, for: UIControlState())
-        tempButton.setTitleColor(UIColor.init(netHex: 0x6d6d6d), for: UIControlState())
+        tempButton.setTitle(title, for: .init())
+        tempButton.setTitleColor(UIColor.init(netHex: 0x6d6d6d), for: .init())
         tempButton.setTitleColor(UIColor.init(netHex: 0xf3f3f4), for: .selected)
         tempButton.titleLabel?.font = UIFont.NFXFont(size: 15)
         tempButton.addTarget(self, action: selector, for: .touchUpInside)
@@ -153,13 +153,13 @@ class NFXDetailsController_iOS: NFXDetailsController, MFMailComposeViewControlle
         moreButton.backgroundColor = UIColor.NFXGray44Color()
         
         if ((forView == EDetailsView.request) && (self.selectedModel.requestBodyLength > 1024)) {
-            moreButton.setTitle("Show request body", for: UIControlState())
+            moreButton.setTitle("Show request body", for: .init())
             moreButton.addTarget(self, action: #selector(NFXDetailsController_iOS.requestBodyButtonPressed), for: .touchUpInside)
             scrollView.addSubview(moreButton)
             scrollView.contentSize = CGSize(width: textLabel.frame.width, height: moreButton.frame.maxY + 16)
 
         } else if ((forView == EDetailsView.response) && (self.selectedModel.responseBodyLength > 1024)) {
-            moreButton.setTitle("Show response body", for: UIControlState())
+            moreButton.setTitle("Show response body", for: .init())
             moreButton.addTarget(self, action: #selector(NFXDetailsController_iOS.responseBodyButtonPressed), for: .touchUpInside)
             scrollView.addSubview(moreButton)
             scrollView.contentSize = CGSize(width: textLabel.frame.width, height: moreButton.frame.maxY + 16)
@@ -223,10 +223,10 @@ class NFXDetailsController_iOS: NFXDetailsController, MFMailComposeViewControlle
         let numButtons = headerButtons.count
 
         switch gesture.direction {
-            case UISwipeGestureRecognizerDirection.left:
+            case .left:
                 let nextIdx = currentButtonIdx + 1
                 buttonPressed(headerButtons[nextIdx > numButtons - 1 ? 0 : nextIdx])
-            case UISwipeGestureRecognizerDirection.right:
+            case .right:
                 let previousIdx = currentButtonIdx - 1
                 buttonPressed(headerButtons[previousIdx < 0 ? numButtons - 1 : previousIdx])
             default: break
@@ -319,6 +319,7 @@ class NFXDetailsController_iOS: NFXDetailsController, MFMailComposeViewControlle
 }
 
 extension NFXDetailsController_iOS: UIActivityItemSource {
+    public typealias UIActivityType = UIActivity.ActivityType
     
     func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
         return "placeholder"

--- a/netfox/iOS/NFXHelper_iOS.swift
+++ b/netfox/iOS/NFXHelper_iOS.swift
@@ -6,11 +6,14 @@
 //
 
 #if os(iOS)
-    
+
 import UIKit
 
-extension UIWindow
-{
+#if swift(>=4.2)
+public typealias UIEventSubtype = UIEvent.EventSubtype
+#endif
+
+extension UIWindow {
     override open func motionEnded(_ motion: UIEventSubtype, with event: UIEvent?)
     {
         if NFX.sharedInstance().getSelectedGesture() == .shake {

--- a/netfox/iOS/NFXListCell_iOS.swift
+++ b/netfox/iOS/NFXListCell_iOS.swift
@@ -11,6 +11,10 @@ import Foundation
     
 import UIKit
 
+#if swift(>=4.2)
+typealias UITableViewCellStyle = UITableViewCell.CellStyle
+#endif
+
 class NFXListCell: UITableViewCell
 {
     

--- a/netfox/iOS/NFXSettingsController_iOS.swift
+++ b/netfox/iOS/NFXSettingsController_iOS.swift
@@ -57,9 +57,9 @@ class NFXSettingsController_iOS: NFXSettingsController, UITableViewDelegate, UIT
         nfxURLButton = UIButton(frame: CGRect(x: 10, y: self.view.frame.height - 40, width: self.view.frame.width - 2*10, height: 30))
         nfxURLButton.autoresizingMask = [.flexibleTopMargin, .flexibleWidth]
         nfxURLButton.titleLabel?.font = UIFont.NFXFont(size: 12)
-        nfxURLButton.setTitleColor(UIColor.NFXGray44Color(), for: UIControlState())
+        nfxURLButton.setTitleColor(UIColor.NFXGray44Color(), for: .init())
         nfxURLButton.titleLabel?.textAlignment = .center
-        nfxURLButton.setTitle(nfxURL, for: UIControlState())
+        nfxURLButton.setTitle(nfxURL, for: .init())
         nfxURLButton.addTarget(self, action: #selector(NFXSettingsController_iOS.nfxURLButtonPressed), for: .touchUpInside)
         self.view.addSubview(nfxURLButton)
         


### PR DESCRIPTION
~~Fixing the entire code base to support both Swift 4, Swift 4.1 and Swift 4.2 will be a bit of a lengthy process.~~

~~For the meanwhile, though, explicitly setting `swift_version` to `4.0` will allow you to install netfox as part of a Xcode 10 project with no issues.~~

Well, eventually I just added support for both Swift 4 and Swift 4.2. 
This PR also gets rid of Swift 3 support, as users who still use it can target older tags/releases.