### PR TITLE
Fixed presenting UIAlertController while using search functionality on iOS.

### DIFF
--- a/netfox/Core/NFXGenericController.swift
+++ b/netfox/Core/NFXGenericController.swift
@@ -20,7 +20,7 @@ class NFXGenericController: NFXViewController
     {
         super.viewDidLoad()
     #if os(iOS)
-        self.edgesForExtendedLayout = UIRectEdge()
+        self.edgesForExtendedLayout = UIRectEdge.all
         self.view.backgroundColor = NFXColor.NFXGray95Color()
     #elseif os(OSX)
         self.view.wantsLayer = true

--- a/netfox/iOS/NFXListController_iOS.swift
+++ b/netfox/iOS/NFXListController_iOS.swift
@@ -25,8 +25,8 @@ class NFXListController_iOS: NFXListController, UITableViewDelegate, UITableView
     {
         super.viewDidLoad()
         
-        self.edgesForExtendedLayout = UIRectEdge()
-        self.extendedLayoutIncludesOpaqueBars = false
+        self.edgesForExtendedLayout = UIRectEdge.all
+        self.extendedLayoutIncludesOpaqueBars = true
         self.automaticallyAdjustsScrollViewInsets = false
         
         self.tableView.frame = self.view.frame
@@ -56,6 +56,7 @@ class NFXListController_iOS: NFXListController, UITableViewDelegate, UITableView
         
         if #available(iOS 11.0, *) {
             self.navigationItem.searchController = self.searchController
+            self.definesPresentationContext = true
         } else {
             let searchView = UIView()
             searchView.frame = CGRect(x: 0, y: 0, width: self.view.frame.width - 60, height: 0)


### PR DESCRIPTION
Steps to reproduce:
Use search to filter requests list. Tap on one search result > use long press in a details screen to copy the response. "Text Copied!" alert is not visible. Closing Netfox results in a crash.