### PR TITLE
Updated NFXProtocol for handling delegate callbacks

### DIFF
--- a/netfox/Core/NFXAuthenticationChallengeSender.swift
+++ b/netfox/Core/NFXAuthenticationChallengeSender.swift
@@ -8,34 +8,34 @@
 
 import Foundation
 
-internal class NFXAuthenticationChallengeSender : NSObject, URLAuthenticationChallengeSender {
+class NFXAuthenticationChallengeSender : NSObject, URLAuthenticationChallengeSender {
     
     typealias NFXAuthenticationChallengeHandler = (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     
-    fileprivate var handler: NFXAuthenticationChallengeHandler
+    let handler: NFXAuthenticationChallengeHandler
     
     init(handler: @escaping NFXAuthenticationChallengeHandler) {
         self.handler = handler
         super.init()
     }
     
-    public func use(_ credential: URLCredential, for challenge: URLAuthenticationChallenge) {
-        handler(URLSession.AuthChallengeDisposition.useCredential, credential)
+    func use(_ credential: URLCredential, for challenge: URLAuthenticationChallenge) {
+        handler(.useCredential, credential)
     }
     
-    public func continueWithoutCredential(for challenge: URLAuthenticationChallenge) {
-        handler(URLSession.AuthChallengeDisposition.useCredential, nil)
+    func continueWithoutCredential(for challenge: URLAuthenticationChallenge) {
+        handler(.useCredential, nil)
     }
 
-    public func cancel(_ challenge: URLAuthenticationChallenge) {
-        handler(URLSession.AuthChallengeDisposition.cancelAuthenticationChallenge, nil)
+    func cancel(_ challenge: URLAuthenticationChallenge) {
+        handler(.cancelAuthenticationChallenge, nil)
     }
 
-    public func performDefaultHandling(for challenge: URLAuthenticationChallenge) {
-        handler(URLSession.AuthChallengeDisposition.performDefaultHandling, nil)
+    func performDefaultHandling(for challenge: URLAuthenticationChallenge) {
+        handler(.performDefaultHandling, nil)
     }
 
-    public func rejectProtectionSpaceAndContinue(with challenge: URLAuthenticationChallenge) {
-        handler(URLSession.AuthChallengeDisposition.rejectProtectionSpace, nil)
+    func rejectProtectionSpaceAndContinue(with challenge: URLAuthenticationChallenge) {
+        handler(.rejectProtectionSpace, nil)
     }
 }

--- a/netfox/Core/NFXProtocol.swift
+++ b/netfox/Core/NFXProtocol.swift
@@ -118,8 +118,19 @@ extension NFXProtocol: URLSessionDataDelegate {
     }
     
     public func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
-        client?.urlProtocol(self, wasRedirectedTo: request, redirectResponse: response)
-        completionHandler(request)
+        
+        let updatedRequest: URLRequest
+        if URLProtocol.property(forKey: NFXProtocol.nfxInternalKey, in: request) != nil {
+            let mutableRequest = (request as NSURLRequest).mutableCopy() as! NSMutableURLRequest
+            URLProtocol.removeProperty(forKey: NFXProtocol.nfxInternalKey, in: mutableRequest)
+            
+            updatedRequest = mutableRequest as URLRequest
+        } else {
+            updatedRequest = request
+        }
+        
+        client?.urlProtocol(self, wasRedirectedTo: updatedRequest, redirectResponse: response)
+        completionHandler(updatedRequest)
     }
     
     public func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {


### PR DESCRIPTION
With the current implementation, using the `URLSession` call with `completionHandler` to perform requests, delegate callbacks are never executed (just check the documentation of `URLSession`). This results in for example redirection not working properly anymore with delegate callbacks. This pull request fixes this by handling all delegate calls properly and not using the `completionHandler` method.