### PR TITLE
Fix for issue #162

### DIFF
--- a/netfox/Core/NFX.swift
+++ b/netfox/Core/NFX.swift
@@ -128,6 +128,10 @@ open class NFX: NSObject
         toggleNFX()
     }
     
+    @objc open func isStarted() -> Bool {
+        return self.started
+    }
+    
     @objc open func setCachePolicy(_ policy: URLCache.StoragePolicy) {
         cacheStoragePolicy = policy
     }


### PR DESCRIPTION
Added isStarted func to get "started" variable's value. It may be needed to implement a switch for starting/stopping NFX by a library's client.