### PR TITLE
Fixes problem of scrolling closure of Semi Modal on iOS 13

### DIFF
--- a/netfox/Core/NFX.swift
+++ b/netfox/Core/NFX.swift
@@ -160,6 +160,12 @@ open class NFX: NSObject
         hideNFX()
     }
 
+    @objc internal func finishPresenting()
+    {
+        guard self.started else { return }
+        self.presented = false
+    }
+
     @objc open func toggle()
     {
         guard self.started else { return }

--- a/netfox/iOS/NFXListController_iOS.swift
+++ b/netfox/iOS/NFXListController_iOS.swift
@@ -92,6 +92,12 @@ class NFXListController_iOS: NFXListController, UITableViewDelegate, UITableView
         super.viewWillAppear(animated)
         reloadTableViewData()
     }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+
+        NFX.sharedInstance().finishPresenting()
+    }
     
     @objc func settingsButtonPressed()
     {


### PR DESCRIPTION
Fixed an issue where `presented` was not `false` when the new iOS 13 semi modal is closed by scrolling.