### PR TITLE
Fix ListController_iOS BackgroundColor for DarkMode

### DIFF
--- a/netfox/iOS/NFXListController_iOS.swift
+++ b/netfox/iOS/NFXListController_iOS.swift
@@ -27,6 +27,7 @@ class NFXListController_iOS: NFXListController, UITableViewDelegate, UITableView
         self.extendedLayoutIncludesOpaqueBars = true
         self.automaticallyAdjustsScrollViewInsets = false
         
+        self.tableView.backgroundColor = .clear
         self.tableView.frame = self.view.frame
         self.tableView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.tableView.translatesAutoresizingMaskIntoConstraints = true


### PR DESCRIPTION
Hi,

i just set the backgroundColor of the tableView inside the `NFXListController_iOS` controller to clear. Otherwise with the darkMode on iOS 13 the cells inside the tableView have a dark background and it's not possible to read.

thanks,
Paolo