### PR TITLE
Fix for issue #179: netfox can't be dismissed after navigate to a call

### DIFF
--- a/netfox/Core/NFX.swift
+++ b/netfox/Core/NFX.swift
@@ -270,7 +270,8 @@ extension NFX {
         navigationController.navigationBar.tintColor = UIColor.NFXOrangeColor()
         navigationController.navigationBar.barTintColor = UIColor.NFXStarkWhiteColor()
         navigationController.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.NFXOrangeColor()]
-        
+        navigationController.modalPresentationStyle = .fullScreen
+
         presentingViewController?.present(navigationController, animated: true, completion: nil)
     }
     

--- a/netfox/Core/NFX.swift
+++ b/netfox/Core/NFX.swift
@@ -160,12 +160,6 @@ open class NFX: NSObject
         hideNFX()
     }
 
-    @objc internal func finishPresenting()
-    {
-        guard self.started else { return }
-        self.presented = false
-    }
-
     @objc open func toggle()
     {
         guard self.started else { return }
@@ -270,7 +264,10 @@ extension NFX {
         navigationController.navigationBar.tintColor = UIColor.NFXOrangeColor()
         navigationController.navigationBar.barTintColor = UIColor.NFXStarkWhiteColor()
         navigationController.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.NFXOrangeColor()]
-        navigationController.modalPresentationStyle = .fullScreen
+
+        if #available(iOS 13.0, *) {
+            navigationController.presentationController?.delegate = self
+        }
 
         presentingViewController?.present(navigationController, animated: true, completion: nil)
     }
@@ -282,6 +279,15 @@ extension NFX {
                 notNilCompletion()
             }
         })
+    }
+}
+
+extension NFX: UIAdaptivePresentationControllerDelegate {
+
+    public func presentationControllerDidDismiss(_ presentationController: UIPresentationController)
+    {
+        guard self.started else { return }
+        self.presented = false
     }
 }
 

--- a/netfox/iOS/NFXListController_iOS.swift
+++ b/netfox/iOS/NFXListController_iOS.swift
@@ -93,12 +93,6 @@ class NFXListController_iOS: NFXListController, UITableViewDelegate, UITableView
         reloadTableViewData()
     }
 
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-
-        NFX.sharedInstance().finishPresenting()
-    }
-    
     @objc func settingsButtonPressed()
     {
         var settingsController: NFXSettingsController_iOS


### PR DESCRIPTION
The PR #172 solved an issue where presented was not false when the new iOS 13 semi modal is closed by scrolling, but unfortunately it created another issue. The Netfox can't be dismissed after navigate to a call, and then get back, described on issue #179.
With this approach i believe the two issues will be resolved.

What do you guys think? 
