### PR TITLE
Feature/enhance capture bodydata

### DIFF
--- a/netfox/Core/NFXProtocol.swift
+++ b/netfox/Core/NFXProtocol.swift
@@ -59,6 +59,7 @@ open class NFXProtocol: URLProtocol
         
         let mutableRequest = (request as NSURLRequest).mutableCopy() as! NSMutableURLRequest
         URLProtocol.setProperty(true, forKey: NFXProtocol.nfxInternalKey, in: mutableRequest)
+        
         if let bodyData = captureRequestBody(mutableRequest as URLRequest) {
             mutableRequest.httpBody = bodyData
         }
@@ -67,6 +68,10 @@ open class NFXProtocol: URLProtocol
     }
     
     func captureRequestBody(_ request: URLRequest) -> Data? {
+        guard let _ = request.httpBody else {
+            return nil
+        }
+        
         guard let bodyStream = request.httpBodyStream else {
             return nil
         }


### PR DESCRIPTION
## Problem
In some cases, the `HTTPBody` is nil which may lead to failing requests.

## Solution
Check if the `HTTPBody` is nil and `httpBodyStream` if not equal to nil then add `HTTPBody` again.