### PR TITLE
Inifinte loop fix in case of multipart request

### DIFF
--- a/netfox/Core/NFXHelper.swift
+++ b/netfox/Core/NFXHelper.swift
@@ -177,9 +177,22 @@ extension URLRequest
         }
     }
     
+    func getNFXContentTypeHeader() -> String? 
+    {
+        return self.value(forHTTPHeaderField: "Content-Type")
+    }
+
+    
     func getNFXBody() -> Data
     {
-        return httpBodyStream?.readfully() ?? URLProtocol.property(forKey: "NFXBodyData", in: self) as? Data ?? Data()
+        if getNFXContentTypeHeader()?.contains("multipart/form-data;") == true 
+        {
+            return Data()
+        }
+        else
+        {
+            return httpBodyStream?.readfully() ?? URLProtocol.property(forKey: "NFXBodyData", in: self) as? Data ?? Data()
+        }
     }
     
     func getCurl() -> String {


### PR DESCRIPTION
Just avoiding the app to go into an infinite loope by discarding the httpBody read process for multipart request only.