### PR TITLE
Fix memory leaks by invalidating session after cancelling tasks

### DIFF
--- a/netfox/Core/NFXProtocol.swift
+++ b/netfox/Core/NFXProtocol.swift
@@ -66,6 +66,7 @@ open class NFXProtocol: URLProtocol
     {
         session.getTasksWithCompletionHandler { dataTasks, _, _ in
             dataTasks.forEach { $0.cancel() }
+            self.session.invalidateAndCancel()
         }
     }
     


### PR DESCRIPTION
Mojio team noticed memory leaks within the networking layer with `netfox` integrated for debugging purposes. After this fix, we no longer see the memory leaks.

You can test this by looking at the memory graph before/after this fix.

Also, from the `URLSession` documentation:

> Important
> The session object keeps a strong reference to the delegate until your app exits or explicitly invalidates the session. If you don’t invalidate the session, your app leaks memory until the app terminates.
