### PR TITLE
By default don't print to the console and add a configuration option to set it to enabled.

### DIFF
--- a/netfox/Core/NFX.swift
+++ b/netfox/Core/NFX.swift
@@ -17,6 +17,11 @@ private func podPlistVersion() -> String? {
     return path
 }
 
+internal func nfxPrint(_ value: String) {
+    guard NFX.sharedInstance().printLoggingEnabled else { return }
+    print(value)
+}
+
 // TODO: Carthage support
 let nfxVersion = podPlistVersion() ?? "0"
 
@@ -69,6 +74,9 @@ open class NFX: NSObject {
         case shake
         case custom
     }
+
+    /// Change this value to `true` to show internal print logging in the console.
+    public var printLoggingEnabled: Bool = false
 
     @objc open func start() {
         guard !started else {

--- a/netfox/Core/NFXHTTPModel.swift
+++ b/netfox/Core/NFXHTTPModel.swift
@@ -166,7 +166,7 @@ fileprivate func < <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
         do {
             try dataString.write(to: fileURL, atomically: true, encoding: .utf8)
         } catch let error {
-            print("[NFX]: Failed to save data to [\(fileURL)] - \(error.localizedDescription)")
+            nfxPrint("[NFX]: Failed to save data to [\(fileURL)] - \(error.localizedDescription)")
         }
     }
     
@@ -174,7 +174,7 @@ fileprivate func < <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
         do {
             return try Data(contentsOf: fileURL)
         } catch let error {
-            print("[NFX]: Failed to load data from [\(fileURL)] - \(error.localizedDescription)")
+            nfxPrint("[NFX]: Failed to load data from [\(fileURL)] - \(error.localizedDescription)")
             return nil
         }
     }

--- a/netfox/Core/NFXHelper.swift
+++ b/netfox/Core/NFXHelper.swift
@@ -344,7 +344,7 @@ struct NFXPath {
         do {
             try FileManager.default.createDirectory(at: nfxDirURL, withIntermediateDirectories: true, attributes: nil)
         } catch let error {
-            print("[NFX]: failed to create working dir - \(error.localizedDescription)")
+            nfxPrint("[NFX]: failed to create working dir - \(error.localizedDescription)")
         }
     }
     
@@ -354,7 +354,7 @@ struct NFXPath {
         do {
             try FileManager.default.removeItem(at: nfxDirURL)
         } catch let error {
-            print("[NFX]: failed to delete working dir - \(error.localizedDescription)")
+            nfxPrint("[NFX]: failed to delete working dir - \(error.localizedDescription)")
         }
     }
     
@@ -394,7 +394,7 @@ extension String {
                 try fileHandle.seekToEnd()
                 try fileHandle.write(contentsOf: data)
             } catch let error {
-                print("[NFX]: Failed to append [\(self.prefix(128))] to \(fileURL), trying to create new file - \(error.localizedDescription)")
+                nfxPrint("[NFX]: Failed to append [\(self.prefix(128))] to \(fileURL), trying to create new file - \(error.localizedDescription)")
                 write(to: fileURL)
             }
         } else {
@@ -408,7 +408,7 @@ extension String {
         do {
             try write(to: fileURL, atomically: true, encoding: .utf8)
         } catch let error {
-            print("[NFX]: Failed to save [\(self.prefix(128))] to \(fileURL) - \(error.localizedDescription)")
+            nfxPrint("[NFX]: Failed to save [\(self.prefix(128))] to \(fileURL) - \(error.localizedDescription)")
         }
     }
     


### PR DESCRIPTION
## The Problem

Netfox pollutes the console with file not found error message for responses whose bodies aren't saved to the file system.

## Solution

By adding configuration to enable and disable the console printing.
